### PR TITLE
Update Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Download the most recent `Monocraft.ttc` file from the [Releases](https://github
 #### Using Homebrew
 
 ```shell
-brew tap homebrew/cask-fonts
 brew install --cask font-monocraft
 ```
 


### PR DESCRIPTION
Monocraft has been migrated to `homebrew-cask` following the deprecation of the `homebrew-cask-fonts` repository (see [pull request](https://github.com/Homebrew/homebrew-cask/pull/173928)).
