### PR TITLE
Add 'ґ' and 'Ґ' glyphs

### DIFF
--- a/src/characters.json
+++ b/src/characters.json
@@ -3661,6 +3661,36 @@
 		"descent": 1
 	},
 	{
+		"character": "Ґ",
+		"name": "cyrillic_capital_letter_ghe_with_upturn",
+		"codepoint": 1168,
+		"pixels": [
+			[0, 0, 0, 0, 1],
+			[0, 0, 0, 0, 1],
+			[1, 1, 1, 1, 1],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0]
+		]
+	},
+	{
+		"character": "ґ",
+		"name": "cyrillic_small_letter_ghe_with_upturn",
+		"codepoint": 1169,
+		"pixels": [
+			[0, 0, 0, 0, 1],
+			[0, 0, 0, 0, 1],
+			[1, 1, 1, 1, 1],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0],
+			[1, 0, 0, 0, 0]
+		]
+	},
+	{
 		"character": "€",
 		"name": "euro_sign",
 		"codepoint": 8364,


### PR DESCRIPTION
Glyphs are pixel-perfect copies from 'accented.png' from Minecraft version 1.20.6.
Capital Ґ has nine pixels height that matches Minecraft version.
Pixel measurements was taken using Gimp and grid feature of it.
Font files from repo are not rebuilt (same as in another PR).

Image generated by `fontimage --text "ґҐ" --fontname dist/Monocraft.ttc`.
![Monocraft](https://github.com/user-attachments/assets/de1ee0ae-2238-4e9d-9e95-f04a64d92273)

Resolves #145
