### PR TITLE
Fixed Hyphen Issue (Issue #180)

### DIFF
--- a/src/monocraft.py
+++ b/src/monocraft.py
@@ -139,13 +139,6 @@ def generateFont(
 		font.em = PIXEL_SIZE * 9
 		font.upos = -PIXEL_SIZE  # Underline position
 		font.addLookup(
-			"ligatures-exp",
-			"gsub_multiple",
-			(),
-			(("ccmp", (("dflt", ("dflt")), ("latn", ("dflt")))),),
-		)
-		font.addLookupSubtable("ligatures-exp", "ligatures-exp-subtable")
-		font.addLookup(
 			"ligatures", "gsub_ligature", (), (("liga", (("dflt", ("dflt")), ("latn", ("dflt")))),)
 		)
 		font.addLookupSubtable("ligatures", "ligatures-subtable")
@@ -215,7 +208,7 @@ def generateFont(
 	for ligature in ligatures:
 		image, kw = generatePixels(ligature)
 		name = ligature["name"].translate(str.maketrans(" ", "_"))
-		createGlyph(fontList, -1, name, image, **kw)
+		createGlyph(fontList, -1, name, image, width=PIXEL_SIZE * 6 * len(ligature["sequence"]), **kw)
 		for font in fontList:
 			if font is None:
 				continue
@@ -227,16 +220,6 @@ def generateFont(
 						lambda codepoint: charactersByCodepoint[codepoint]["name"],
 						ligature["sequence"],
 					)
-				),
-			)
-			lig.addPosSub(
-				"ligatures-exp-subtable",
-				(
-					name,
-					*(
-						charactersByCodepoint[32]["name"]
-						for _ in range(len(ligature["sequence"]) - 1)
-					),
 				),
 			)
 


### PR DESCRIPTION
https://github.com/IdreesInc/Monocraft/issues/180

Fixed the bug where long hyphens (16+) were vanishing.

Turns out it was hitting a hard limit in HarfBuzz/Kitty. We were using GSUB to swap ligatures for a string of spaces to get the width right, but that caps out at 15 glyphs. Anything longer just failed silently.

The fix was simple: I stopped the ccmp expansion and just set the advance width directly on the glyph. The art is already the right size, so now it just works without the extra steps. This covers arrows, hyphens, and whatever else, regardless of length.